### PR TITLE
FEAT: added env-file feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ goenvtemplator -help
 Usage of goenvtemplator:
   -debug-templates
     	Print processed templates to stdout.
+  -env-file value
+        Additional file with environment variables. Can be passed multiple times. (default [])
   -exec
     	Activates exec by command. First non-flag arguments is the command, the rest are it's arguments.
   -template value
@@ -44,6 +46,38 @@ goenvtemplator -template /path/to/server.conf.tmpl:/path/to/server.conf  -templa
 ```Dockerfile
 ENTRYPOINT ["/usr/local/bin/goenvtemplator", "-template", "/path/to/server.conf.tmpl:/path/to/server.conf", "-exec"]
 CMD ["/usr/bin/server-binary", "server-argument1", "server-argument2", "..."]
+```
+
+### Env files
+It is possible to add additional environment variables in multiple env-files.
+Existing variables are **not** overwritten.
+Environment variables in files can be formated using shell syntax or yaml syntax.
+
+Let us consider an environment file `myenvfile` bellow.
+```bash
+# cat myenvfile
+A=a
+B=b
+B=bb
+#B=bbb
+export C=c
+# yaml syntax
+D: d
+```
+
+The behaviour of env-file argument and env variables evaluation is as follows:
+```
+goenvtemplator -env-file myenvfile -exec sh -c 'echo $A'
+> a
+export A=foo
+goenvtemplator -env-file myenvfile -exec sh -c 'echo $A'
+> foo
+goenvtemplator -env-file myenvfile -exec sh -c 'echo $B'
+> bb
+goenvtemplator -env-file myenvfile -exec sh -c 'echo $C'
+> c
+goenvtemplator -env-file myenvfile -exec sh -c 'echo $D'
+> d
 ```
 
 ## Using Templates

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,9 @@ goenvtemplator (1.1.0) UNRELEASED; urgency=medium
 
   * Table driven tests.
   * Removed hard coded env key from key.
+  * Added support of env files.
 
- -- Tomas Dohnalek <tomas.dohnalek@firma.seznam.cz>  Wed, 23 Nov 2016 15:23:48 +0100
+ -- Tomas Dohnalek <tomas.dohnalek@firma.seznam.cz>  Mon, 08 Feb 2016 16:33:27 +0100
 
 goenvtemplator (1.0.0) testing; urgency=medium
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,6 @@
+hash: 2e49700d65abd2ec5287560ff1c0eb932322e097aef96cae137da9cb4f5b0b0f
+updated: 2016-11-23T16:52:10.769828004+01:00
+imports:
+- name: github.com/joho/godotenv
+  version: a01a834e1654b4c9ca5b3ad05159445cc9c7ad08
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/seznam/goenvtemplator
+import:
+- package: github.com/joho/godotenv
+  version: v1

--- a/goenvtemplator.go
+++ b/goenvtemplator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/joho/godotenv"
 	"log"
 	"os"
 	"os/exec"
@@ -39,6 +40,18 @@ func (ts *templatesPaths) String() string {
 	return fmt.Sprintf("%v", *ts)
 }
 
+// to parse slice of strings from flags we need to use custom type
+type envFiles []string
+
+func (ef *envFiles) Set(value string) error {
+	*ef = append(*ef, value)
+	return nil
+}
+
+func (ef *envFiles) String() string {
+	return fmt.Sprintf("%v", *ef)
+}
+
 func generateTemplates(ts templatesPaths, debug bool) error {
 	for _, t := range ts {
 		if v > 0 {
@@ -65,9 +78,19 @@ func main() {
 	flag.BoolVar(&doExec, "exec", false, "Activates exec by command. First non-flag arguments is the command, the rest are it's arguments.")
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "Prints version.")
+	var envFileList envFiles
+	flag.Var(&envFileList, "env-file", "Additional file with environment variables. Can be passed multiple times.")
 	flag.IntVar(&v, "v", 0, "Verbosity level.")
 
 	flag.Parse()
+
+	// if no env-file was passed, godotenv.Load loads .env file by default, we want to disable this
+	if len(envFileList) > 0 {
+		err := godotenv.Load(envFileList...)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	if printVersion {
 		log.Printf("Version: %s", buildVersion)


### PR DESCRIPTION
#### PR description
* possible to add multiple (or none) `-env-file` arguments with files
* if file cannot be read it fails
* env-files are passed to a third party library `github.com/joho/godoten` which loads environment variables from those files
* if variable already exists in env and also in file, the variable is **not** overwritten (can be changed when used `godotenv.Overload` function)
* if variable exists in env-file A and env-file B, than only the first one is used as env (so order of `-env-file` arguments matters)
* doc

#### Missing
* dependencies (folder `vendor`)