### PR TITLE
Td xml parsing

### DIFF
--- a/template.go
+++ b/template.go
@@ -50,12 +50,14 @@ var funcMap = template.FuncMap{
 func generateTemplate(source, name string) (string, error) {
 	var t *template.Template
 	var err error
-	t, err = template.New(name).Option("missingkey=zero").Funcs(funcMap).Funcs(sprig.TxtFuncMap()).Parse(source)
+	t, err = template.New(name).Option("missingkey=error").Funcs(funcMap).Funcs(sprig.TxtFuncMap()).Parse(source)
 	if err != nil {
 		return "", err
 	}
 	var buffer bytes.Buffer
-	if err = t.Execute(&buffer, nil); err != nil {
+	// hacking because go 1.7 fails to throw error, see https://github.com/golang/go/commit/277bcbbdcd26f2d64493e596238e34b47782f98e
+	emptyHash := map[string]interface{}{}
+	if err = t.Execute(&buffer, &emptyHash); err != nil {
 		return "", err
 	}
 	return buffer.String(), nil

--- a/template.go
+++ b/template.go
@@ -1,15 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"path/filepath"
-	//	"io/ioutil"
-	"bytes"
 	"github.com/Masterminds/sprig"
-	"html/template"
 	"io/ioutil"
 	"log"
+	"path/filepath"
+	"text/template"
 )
 
 type OptionalString struct {
@@ -51,7 +50,7 @@ var funcMap = template.FuncMap{
 func generateTemplate(source, name string) (string, error) {
 	var t *template.Template
 	var err error
-	t, err = template.New(name).Funcs(funcMap).Funcs(sprig.FuncMap()).Parse(source)
+	t, err = template.New(name).Option("missingkey=zero").Funcs(funcMap).Funcs(sprig.TxtFuncMap()).Parse(source)
 	if err != nil {
 		return "", err
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -22,6 +22,7 @@ func TestGenerateTemplate(t *testing.T) {
 		{`K={{ env "NONEXISTING"| default "default value" }}`, `K=default value`, nil},
 		{`{{ "hi!" | upper | repeat 3 }}`, `HI!HI!HI!`, nil},
 		{`{{$v := "foo/bar/baz" | split "/"}}{{$v._1}}`, `bar`, nil},
+		{`<?xml version="1.0"?>`, `<?xml version="1.0"?>`, nil},
 	}
 
 	templateName := "test"

--- a/template_test.go
+++ b/template_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"github.com/joho/godotenv"
 	"os"
+	"reflect"
 	"testing"
+	"text/template"
 )
 
 func TestGenerateTemplate(t *testing.T) {
+	templateName := "test"
 	var tests = []struct {
 		in   string
 		want string
@@ -15,8 +18,8 @@ func TestGenerateTemplate(t *testing.T) {
 		{`K={{ env "GOENVTEMPLATOR_DEFINED_VAR" }}`, `K=foo`, nil},
 		{`K={{ env "GOENVTEMPLATOR_DEFINED_FILE_VAR" }}`, `K=bar`, nil},
 		{`K={{ env "NONEXISTING" }}`, `K=`, nil},
-		{`K={{ .NONEXISTING }}`, `K=`, nil},
-		{`K={{ .NonExisting | default "default value" }}`, `K=default value`, nil},
+		{`K={{ .NONEXISTING }}`, ``, template.ExecError{}},
+		{`K={{ .NonExisting | default "default value" }}`, ``, template.ExecError{}},
 		{`K={{ env "GOENVTEMPLATOR_DEFINED_VAR" | default "xxx" }}`, `K=foo`, nil},
 		{`K={{ env "GOENVTEMPLATOR_DEFINED_FILE_VAR" | default "xxx" }}`, `K=bar`, nil},
 		{`K={{ env "NONEXISTING"| default "default value" }}`, `K=default value`, nil},
@@ -25,8 +28,6 @@ func TestGenerateTemplate(t *testing.T) {
 		{`<?xml version="1.0"?>`, `<?xml version="1.0"?>`, nil},
 	}
 
-	templateName := "test"
-
 	os.Setenv("GOENVTEMPLATOR_DEFINED_VAR", "foo")
 
 	err := godotenv.Load("./tests/fixtures.env")
@@ -34,15 +35,17 @@ func TestGenerateTemplate(t *testing.T) {
 		t.Errorf("Cannot load env file: %q", err)
 	}
 
-	for _, tt := range tests {
-		got, gotErr := generateTemplate(tt.in, templateName)
+	for _, testcase := range tests {
+		got, gotErr := generateTemplate(testcase.in, templateName)
 
-		if tt.want != got {
-			t.Errorf("generateTemplate(%q, %q) => (%q, _), want (%q, _)", tt.in, templateName, got, tt.want)
+		if testcase.want != got {
+			t.Errorf("generateTemplate(%q, %q) => (%q, _), want (%q, _)", testcase.in, templateName, got, testcase.want)
 		}
 
-		if tt.err != gotErr {
-			t.Errorf("generateTemplate(%q, %q) => (_, %q), want (_, %q)", tt.in, templateName, gotErr, tt.err)
+		errType, gotErrType := reflect.TypeOf(testcase.err), reflect.TypeOf(gotErr)
+
+		if errType != gotErrType {
+			t.Errorf("generateTemplate(%q, %q) => (_, %q), want (_, %q)", testcase.in, templateName, gotErrType, errType)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8, but...

I have no idea why @lksv switched from `text/template` to `html/template`, if there was some special reason.

Also, now one test fails:
```bash
# make test
--- FAIL: TestGenerateTemplate (0.00s)
	template_test.go:41: generateTemplate("K={{ .NONEXISTING }}", "test") => ("K=<no value>", _), want ("K=", _)
...
```

But 
```bash
# cat a 
K={{ .NONEXISTING }}
# goenvtemplator2 -template $PWD/a:/dev/stdout
K= 
```

Which seems correct, no idea why the test seems to return different value than the binary...

@lksv @freznicek @balous