### PR TITLE
Mch change delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 goenvtemplator
 goenvtemplator-amd64
 goenvtemplator.tar.xz
+
+goenvtemplator2
+goenvtemplator2-amd64
+goenvtemplator2.tar.xz

--- a/README.md
+++ b/README.md
@@ -30,19 +30,23 @@ make
 ## Usage
 goenvtemplator2 -help
 ```
-Usage of goenvtemplator:
+Usage of goenvtemplator2:
   -debug-templates
-    	Print processed templates to stdout.
+        Print processed templates to stdout.
+  -delim-left string
+        Override default left delimiter {{.
+  -delim-right string
+        Override default right delimiter }}.
   -env-file value
-        Additional file with environment variables. Can be passed multiple times. (default [])
+        Additional file with environment variables. Can be passed multiple times.
   -exec
-    	Activates exec by command. First non-flag arguments is the command, the rest are it's arguments.
+        Activates exec by command. First non-flag arguments is the command, the rest are it's arguments.
   -template value
-    	Template (/template:/dest). Can be passed multiple times. (default [])
+        Template (/template:/dest). Can be passed multiple times.
   -v int
-    	Verbosity level.
+        Verbosity level.
   -version
-    	Prints version.
+        Prints version.
 ```
 
 ### Example
@@ -95,3 +99,12 @@ and [Sprig](https://github.com/Masterminds/sprig) library.
 ### Built-in functions
 There are a few built in functions as well:
   * `require (env "ENV_NAME")` - Renders an error if environments variable does not exists. If it is equal to empty string, returns empty string.  `{{ require (env "TIMEOUT_MS) }}`
+
+### Nested Go templates
+If you have nested Go templates there is problem with escaping. To resolve this problem you can define different 
+delimiters of template tags using `-delim-left` and `-delim-right` command line arguments.
+
+Example of templating with `[[ ]]` instead of `{{ }}` delimiters
+```bash
+goenvtemplator2 -template /foo/bar.tmpl:/bar/foo.conf -delim-left [[ -delim-right ]]
+```

--- a/goenvtemplator.go
+++ b/goenvtemplator.go
@@ -52,12 +52,12 @@ func (ef *envFiles) String() string {
 	return fmt.Sprintf("%v", *ef)
 }
 
-func generateTemplates(ts templatesPaths, debug bool) error {
+func generateTemplates(ts templatesPaths, debug bool, delimLeft string, delimRight string) error {
 	for _, t := range ts {
 		if v > 0 {
 			log.Printf("generating %s -> %s", t.source, t.destination)
 		}
-		if err := generateFile(t.source, t.destination, debug); err != nil {
+		if err := generateFile(t.source, t.destination, debug, delimLeft, delimRight); err != nil {
 			return fmt.Errorf("Error while generating '%s' -> '%s'. %v", t.source, t.destination, err)
 		}
 	}
@@ -80,6 +80,10 @@ func main() {
 	flag.BoolVar(&printVersion, "version", false, "Prints version.")
 	var envFileList envFiles
 	flag.Var(&envFileList, "env-file", "Additional file with environment variables. Can be passed multiple times.")
+	var delimLeft string
+	flag.StringVar(&delimLeft, "delim-left", "", "Override default left delimiter {{.")
+	var delimRight string
+	flag.StringVar(&delimRight, "delim-right", "", "Override default right delimiter }}.")
 	flag.IntVar(&v, "v", 0, "Verbosity level.")
 
 	flag.Parse()
@@ -101,7 +105,7 @@ func main() {
 		log.Print("Generating templates")
 	}
 
-	if err := generateTemplates(tmpls, debugTemplates); err != nil {
+	if err := generateTemplates(tmpls, debugTemplates, delimLeft, delimRight); err != nil {
 		log.Fatal(err)
 	}
 

--- a/template.go
+++ b/template.go
@@ -47,10 +47,10 @@ var funcMap = template.FuncMap{
 	"require": Require,
 }
 
-func generateTemplate(source, name string) (string, error) {
+func generateTemplate(source, name string, delimLeft string, delimRight string) (string, error) {
 	var t *template.Template
 	var err error
-	t, err = template.New(name).Option("missingkey=error").Funcs(funcMap).Funcs(sprig.TxtFuncMap()).Parse(source)
+	t, err = template.New(name).Delims(delimLeft, delimRight).Option("missingkey=error").Funcs(funcMap).Funcs(sprig.TxtFuncMap()).Parse(source)
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +63,7 @@ func generateTemplate(source, name string) (string, error) {
 	return buffer.String(), nil
 }
 
-func generateFile(templatePath, destinationPath string, debugTemplates bool) error {
+func generateFile(templatePath, destinationPath string, debugTemplates bool, delimLeft string, delimRight string) error {
 	if !filepath.IsAbs(templatePath) {
 		return fmt.Errorf("Template path '%s' is not absolute!", templatePath)
 	}
@@ -78,7 +78,7 @@ func generateFile(templatePath, destinationPath string, debugTemplates bool) err
 		return err
 	}
 	s := string(slice)
-	result, err := generateTemplate(s, filepath.Base(templatePath))
+	result, err := generateTemplate(s, filepath.Base(templatePath), delimLeft, delimRight)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@dohnto 

This PR should enable setting delimiters of template tags using [Delims](https://golang.org/pkg/text/template/#Template.Delims)

It allows user to specify `--delim-left` and `--delim-right` and override default `{{ }}` 

There is no check if left and right delimiters are the same type. This is user responsibility.
  