### PR TITLE
fix: require function stopped to working

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tool to template configuration files by environment variables and optionally rep
 
 goenvtemplator is a simple app, that can template your config files by environment variables and optionally replace itself (by exec syscall) with the application binary. So at the end your application runs directly under the process that run this tool like docker as if it was originally the entrypoint itself.
 
-This tool is ideal for use without polluting you environment with dependencies. It is fully statically linked so it has no dependencies whatsoever. If you use Dockerfile you don't even need wget or curl since it can be installed only by dockerfile's ADD instruction. 
+This tool is ideal for use without polluting you environment with dependencies. It is fully statically linked so it has no dependencies whatsoever. If you use Dockerfile you don't even need wget or curl since it can be installed only by dockerfile's ADD instruction.
 
 ## Installation
 wget
@@ -98,11 +98,11 @@ and [Sprig](https://github.com/Masterminds/sprig) library.
 
 ### Built-in functions
 There are a few built in functions as well:
-  * `{{ require (env "ENV_NAME") }}` - Renders an error if environments variable does not exists. If it is equal to empty string, returns empty string.  `{{ require (env "TIMEOUT_MS) }}`
+  * `{{ required  "Error message" Value }}` - Raises an error if `Value` is nil or it is equal to empty string. For example `{{ required "TIMEOUT_MS must be set!" (env "TIMEOUT_MS) }}`
   * `{{ range $key, $value := envall }}{{ $key }}={{ $value }};{{ end }}` - Loop over every environment variable.
 
 ### Nested Go templates
-If you have nested Go templates there is problem with escaping. To resolve this problem you can define different 
+If you have nested Go templates there is problem with escaping. To resolve this problem you can define different
 delimiters of template tags using `-delim-left` and `-delim-right` command line arguments.
 
 Example of templating with `[[ ]]` instead of `{{ }}` delimiters

--- a/template_test.go
+++ b/template_test.go
@@ -33,9 +33,17 @@ func TestGenerateTemplate(t *testing.T) {
 		{in: `<?xml version="1.0"?>`, want: `<?xml version="1.0"?>`},
 		{in: `K={{env "GOENVTEMPLATOR_DEFINED_VAR"}}`, want: `K={{env "GOENVTEMPLATOR_DEFINED_VAR"}}`, err: nil, leftDelim: "[[", rightDelim: "]]"},
 		{in: `K=[[env "GOENVTEMPLATOR_DEFINED_VAR"]]`, want: `K=foo`, err: nil, leftDelim: "[[", rightDelim: "]]"},
+		{in: `K={{ require (env "FOO" )}}`, err: template.ExecError{}},
+		{in: `K={{ require (env "GOENVTEMPLATOR_DEFINED_VAR" )}}`, want: `K=foo`},
+		{in: `K={{ require (env "GOENVTEMPLATOR_DEFINED_VAR_EMPTY" )}}`, err: template.ExecError{}},
+		{in: `K={{ required "message" (env "GOENVTEMPLATOR_DEFINED_VAR_EMPTY") }}`, err: template.ExecError{}},
+		{in: `K={{ required "message" (env "GOENVTEMPLATOR_DEFINED_VAR_EMPTY" | default "foo") }}`, want: `K=foo`},
+		{in: `K={{ required "message" "foo" }}`, want: `K=foo`},
+		{in: `K={{ required "message" "" }}`, err: template.ExecError{}},
 	}
 
 	os.Setenv("GOENVTEMPLATOR_DEFINED_VAR", "foo")
+	os.Setenv("GOENVTEMPLATOR_DEFINED_VAR_EMPTY", "")
 
 	err := godotenv.Load("./tests/fixtures.env")
 	if err != nil {


### PR DESCRIPTION
fix: require function stopped to working
    
As described in #10, the `require` function stopped working
in v2 since spring passes empty string even if env variable
does not exists.
    
This fix present changes in proclaimed behaviour of require function.
Now, it raises and error even if env variable is defined but is empty.


in v1

```
$ cat tmp 
jen pockej, {{ require (env "kdo") }}
$ ./goenvtemplator -template `pwd`/tmp:/dev/stdout
raises an error
$ export kdo=""
$ ./goenvtemplator -template `pwd`/tmp:/dev/stdout
ok
```

in v2

```
$ cat tmp 
jen pockej, {{ require (env "kdo") }}
$ ./goenvtemplator2 -template `pwd`/tmp:/dev/stdout
raises an error
$ export kdo=""
$ ./goenvtemplator2 -template `pwd`/tmp:/dev/stdout
raises an error
```

@fusakla @balous @lksv @freznicek