### PR TITLE
chore: add CI tests and lint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,6 @@
 name: goreleaser
 
-on:
-  pull_request:
-  push:
+on: [pull_request, push]
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,43 @@
+name: test
+on: [push]
+jobs:
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - run: make test
+
+  go-mod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check go mod
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          skip-go-installation: true
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,20 @@
+release:
+  github:
+    owner: seznam
+    name: goenvtemplator
+  prerelease: auto
+  draft: true
+  name_template: "v{{.Version}}"
+
+changelog:
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+
+builds:
+  - main: .
+    id: "goenvtemplator"
+    binary: goenvtemplator2
+    goos:
+      - linux

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BINARY       ?= goenvtemplator2
 
 LDFLAGS :=-X main.buildVersion=$(TAG)
 
-.PHONY: all build test release clean install
+.PHONY: all build test release clean install lint
 
 build:
 	go build -o $(BINARY) -ldflags "$(LDFLAGS)"
@@ -19,6 +19,9 @@ install:
 
 test:
 	go test
+
+lint:
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.42.0 golangci-lint run -v
 
 release:
 	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o goenvtemplator2-amd64

--- a/README.md
+++ b/README.md
@@ -114,3 +114,7 @@ Example of templating with `[[ ]]` instead of `{{ }}` delimiters
 ```bash
 goenvtemplator2 -template /foo/bar.tmpl:/bar/foo.conf -delim-left [[ -delim-right ]]
 ```
+
+## Development
+Make sure you pass the CI. If the output of the GitHub actions is not descriptive enough,
+or you can check it before submitting the code, use the `make test` and `make lint`.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/template_test.go
+++ b/template_test.go
@@ -27,6 +27,9 @@ func getTmpFile(t *testing.T, content string) (string, string, func()) {
 		t.Fatal(err)
 	}
 	rel, err := filepath.Rel(wd, abs)
+	if err != nil {
+		t.Fatal(err)
+	}
 	_, err = tmpFile.WriteString(content)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Signed-off-by: Martin Chodur <m.chodur@seznam.cz>

@seznam/sklik-devops-sre @dohnto

I wanted to try out GitHub actions, so I took advantage of goenvtemplator not having any CI and added it.
I like it, it's quite easy to set up and get going. 

On the other hand, I don't like:
 - having go version on multiple places
 - having the golangci-lint version on multiple places
  
  But considering we don't have any CI at the moment and looking at the commit frequency, I'd say this is good enough as a start.  

WDYT?